### PR TITLE
Clock problem

### DIFF
--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,28 +1,28 @@
 use std::fmt::Display;
 
-const DAY: i32 = 24 * 60;
-const HOUR: i32 = 60;
-
 #[derive(Debug, PartialEq)]
 pub struct Clock {
+    hours: i32,
     minutes: i32,
 }
 
 impl Display for Clock {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:02}:{:02}", self.minutes / HOUR, self.minutes % HOUR)
+        write!(f, "{:02}:{:02}", self.hours, self.minutes)
     }
 }
 
 impl Clock {
     pub fn new(hours: i32, minutes: i32) -> Self {
-        Clock {
-            minutes: (((hours * HOUR + minutes) % DAY) + DAY) % DAY,
+        let total_hours = (hours * 60 + minutes).rem_euclid(24 * 60);
+        Self {
+            hours: total_hours / 60,
+            minutes: total_hours % 60,
         }
     }
 
     pub fn add_minutes(&self, minutes: i32) -> Self {
-        Clock::new(0, self.minutes + minutes)
+        Clock::new(self.hours, self.minutes + minutes)
     }
 }
 


### PR DESCRIPTION
- Update version

The "rem_euclid" method is a commonly used algorithm to find the greatest common divisor (GCD) of two positive integers. It is also known as the Euclidean algorithm.

The basic idea of the algorithm is to repeatedly subtract the smaller number from the larger number until one of the numbers becomes zero. The other number at this point is the GCD of the original two numbers.

Here is the pseudocode for the rem_euclid method:

arduino
Copy code
function rem_euclid(a, b):
    if b == 0:
        return a
    else:
        return rem_euclid(b, a % b)
In this pseudocode, a and b are the two positive integers for which we want to find the GCD. The % operator represents the modulo operation, which gives the remainder when a is divided by b.

The algorithm works as follows:

If b is zero, then a is the GCD of the original two numbers, so we return a.
Otherwise, we call the rem_euclid function recursively with b and the remainder of a divided by b as arguments.
The algorithm continues to call itself recursively with smaller and smaller values of b until b eventually becomes zero. At this point, we have found the GCD of the original two numbers, and the recursion unwinds to return that value.